### PR TITLE
Separate routing tables and security groups

### DIFF
--- a/HA/6.2/DualAZ/BaseVPC_FGCP_DualAZ.template.json
+++ b/HA/6.2/DualAZ/BaseVPC_FGCP_DualAZ.template.json
@@ -405,7 +405,55 @@
 				]
 			}
 		},
-		"Route1": {
+		"PrivateRouteTable": {
+			"Type": "AWS::EC2::RouteTable",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Join": [
+								"-",
+								[
+									{
+										"Ref": "AWS::StackName"
+									},
+									"PrivateRouteTable"
+								]
+							]
+						}
+					}
+				]
+			}
+		},
+		"HASyncRouteTable": {
+			"Type": "AWS::EC2::RouteTable",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Join": [
+								"-",
+								[
+									{
+										"Ref": "AWS::StackName"
+									},
+									"HASyncRouteTable"
+								]
+							]
+						}
+					}
+				]
+			}
+		},
+		"PublicRoute1": {
 			"Type": "AWS::EC2::Route",
 			"DependsOn": "AttachGateway",
 			"Properties": {
@@ -418,7 +466,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation1": {
+		"PublicSubnetRouteTableAssociation1": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -429,7 +477,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation2": {
+		"PublicSubnetRouteTableAssociation2": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -440,7 +488,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation3": {
+		"PublicSubnetRouteTableAssociation3": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -451,7 +499,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation4": {
+		"PublicSubnetRouteTableAssociation4": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -459,6 +507,50 @@
 				},
 				"RouteTableId": {
 					"Ref": "PublicRouteTable"
+				}
+			}
+		},
+		"PrivateSubnetRouteTableAssociation1": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "PrivateSub1"
+				},
+				"RouteTableId": {
+					"Ref": "PrivateRouteTable"
+				}
+			}
+		},
+		"PrivateSubnetRouteTableAssociation2": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "PrivateSub2"
+				},
+				"RouteTableId": {
+					"Ref": "PrivateRouteTable"
+				}
+			}
+		},
+		"HASyncSubnetRouteTableAssociation1": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "HASyncSub1"
+				},
+				"RouteTableId": {
+					"Ref": "HASyncRouteTable"
+				}
+			}
+		},
+		"HASyncSubnetRouteTableAssociation2": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "HASyncSub2"
+				},
+				"RouteTableId": {
+					"Ref": "HASyncRouteTable"
 				}
 			}
 		}

--- a/HA/6.2/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/HA/6.2/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -32,6 +32,7 @@
 						"AZForFGT2",
 						"KeyPair",
 						"S3EndpointDeployment",
+						"PrivateSubnet2RouteTableID",
 						"PublicSubnet2RouteTableID",
 						"InitS3Bucket",
 						"InitS3BucketRegion",
@@ -243,6 +244,10 @@
 				"UseExisting"
 			]
 		},
+		"PrivateSubnet2RouteTableID": {
+			"Type": "String",
+			"Description": "To create a route table entry for internal traffic, provide the route table ID associated to PrivateSubnet2"
+		},
 		"PublicSubnet2RouteTableID": {
 			"Type": "String",
 			"Description": "If a new S3 Endpoint is to be deployed, provide the route table ID associated to PublicSubnet2"
@@ -397,25 +402,44 @@
 				]
 			}
 		},
-		"FortiGateSecGrp": {
+		"FortiGatePublicSecGrp": {
 			"Type": "AWS::EC2::SecurityGroup",
 			"Properties": {
 				"VpcId": {
 					"Ref": "VPCID"
 				},
-				"GroupDescription": "FortigateSecGrp",
+				"GroupDescription": "FortiGatePublicSecGrp",
 				"SecurityGroupIngress": [
 					{
-						"Description": "Allow remote access to FGT",
+						"Description": "Allow remote access to FGT for the public subnet",
 						"IpProtocol": "-1",
 						"FromPort": "0",
 						"ToPort": "65535",
 						"CidrIp": {
 							"Ref": "CIDRForInstanceAccess"
 						}
-					},
+					}
+				],
+				"Tags": [
 					{
-						"Description": "Allow local VPC access to FGT",
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-public"
+						}
+					}
+				]
+			}
+		},
+		"FortiGatePrivateSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortiGatePrivateSecGrp",
+				"SecurityGroupIngress": [
+					{
+						"Description": "Allow local VPC access to FGT for the private subnet",
 						"IpProtocol": "-1",
 						"FromPort": "0",
 						"ToPort": "65535",
@@ -423,22 +447,75 @@
 							"Ref": "VPCCIDR"
 						}
 					}
+				],
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-private"
+						}
+					}
 				]
 			}
 		},
-		"FortiGateSecGrpHArule": {
-			"DependsOn": "FortiGateSecGrp",
+		"FortiGateHAMgmtSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortiGateHAMgmtSecGrp",
+				"SecurityGroupIngress": [
+					{
+						"Description": "Allow remote access to FGT for the HA management subnet",
+						"IpProtocol": "-1",
+						"FromPort": "0",
+						"ToPort": "65535",
+						"CidrIp": {
+							"Ref": "CIDRForInstanceAccess"
+						}
+					}
+				],
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-hamgmt"
+						}
+					}
+				]
+			}
+		},
+		"FortiGateHASyncSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortigateHASyncSecGrp",
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-hasync"
+						}
+					}
+				]
+			}
+		},
+		"FortiGateHASyncSecGrpRule": {
+			"DependsOn": "FortiGateHASyncSecGrp",
 			"Type": "AWS::EC2::SecurityGroupIngress",
 			"Properties": {
 				"GroupId": {
-					"Ref": "FortiGateSecGrp"
+					"Ref": "FortiGateHASyncSecGrp"
 				},
-				"Description": "Allow FGTs to access each other",
+				"Description": "Allow FGTs to access each other via HA Sync subnet",
 				"IpProtocol": "-1",
 				"FromPort": "0",
 				"ToPort": "65535",
 				"SourceSecurityGroupId": {
-					"Ref": "FortiGateSecGrp"
+					"Ref": "FortiGateHASyncSecGrp"
 				}
 			}
 		},
@@ -639,7 +716,7 @@
 				"Description": "port1",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePublicSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -692,7 +769,7 @@
 				"Description": "port1",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePublicSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -794,7 +871,7 @@
 				"Description": "port2",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePrivateSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -838,7 +915,7 @@
 				"Description": "port2",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePrivateSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -882,7 +959,7 @@
 				"Description": "port3",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHASyncSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -926,7 +1003,7 @@
 				"Description": "port4",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHAMgmtSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -970,7 +1047,7 @@
 				"Description": "port3",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHASyncSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -1014,7 +1091,7 @@
 				"Description": "port4",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHAMgmtSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -1532,6 +1609,18 @@
 							"}"
 						]
 					]
+				}
+			}
+		},
+		"PrivateRoute1": {
+			"Type": "AWS::EC2::Route",
+			"Properties": {
+				"RouteTableId": {
+					"Ref": "PrivateSubnet2RouteTableID"
+				},
+				"DestinationCidrBlock": "0.0.0.0/0",
+				"NetworkInterfaceId": {
+					"Ref": "fgt1eni1"
 				}
 			}
 		}

--- a/HA/6.2/SingleAZ/BaseVPC_FGCP_SingleAZ.template.json
+++ b/HA/6.2/SingleAZ/BaseVPC_FGCP_SingleAZ.template.json
@@ -256,7 +256,55 @@
 				]
 			}
 		},
-		"Route1": {
+		"PrivateRouteTable": {
+			"Type": "AWS::EC2::RouteTable",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Join": [
+								"-",
+								[
+									{
+										"Ref": "AWS::StackName"
+									},
+									"PrivateRouteTable"
+								]
+							]
+						}
+					}
+				]
+			}
+		},
+		"HASyncRouteTable": {
+			"Type": "AWS::EC2::RouteTable",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Join": [
+								"-",
+								[
+									{
+										"Ref": "AWS::StackName"
+									},
+									"HASyncRouteTable"
+								]
+							]
+						}
+					}
+				]
+			}
+		},
+		"PublicRoute1": {
 			"Type": "AWS::EC2::Route",
 			"DependsOn": "AttachGateway",
 			"Properties": {
@@ -269,7 +317,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation1": {
+		"PublicSubnetRouteTableAssociation1": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -280,7 +328,7 @@
 				}
 			}
 		},
-		"SubnetRouteTableAssociation3": {
+		"PublicSubnetRouteTableAssociation2": {
 			"Type": "AWS::EC2::SubnetRouteTableAssociation",
 			"Properties": {
 				"SubnetId": {
@@ -288,6 +336,28 @@
 				},
 				"RouteTableId": {
 					"Ref": "PublicRouteTable"
+				}
+			}
+		},
+		"PrivateSubnetRouteTableAssociation1": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "PrivateSub1"
+				},
+				"RouteTableId": {
+					"Ref": "PrivateRouteTable"
+				}
+			}
+		},
+		"HASyncSubnetRouteTableAssociation1": {
+			"Type": "AWS::EC2::SubnetRouteTableAssociation",
+			"Properties": {
+				"SubnetId": {
+					"Ref": "HASyncSub1"
+				},
+				"RouteTableId": {
+					"Ref": "HASyncRouteTable"
 				}
 			}
 		}

--- a/HA/6.2/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
+++ b/HA/6.2/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
@@ -27,6 +27,7 @@
 						"AZForInstances",
 						"KeyPair",
 						"S3EndpointDeployment",
+						"PrivateSubnetRouteTableID",
 						"PublicSubnetRouteTableID",
 						"InitS3Bucket",
 						"InitS3BucketRegion",
@@ -223,6 +224,10 @@
 				"UseExisting"
 			]
 		},
+		"PrivateSubnetRouteTableID": {
+			"Type": "String",
+			"Description": "To create a route table entry for internal traffic, provide the route table ID associated to PrivateSubnet2"
+		},
 		"PublicSubnetRouteTableID": {
 			"Type": "String",
 			"Description": "If a new S3 Endpoint is to be deployed, provide the route table ID associated to PublicSubnet"
@@ -376,25 +381,44 @@
 				]
 			}
 		},
-		"FortiGateSecGrp": {
+		"FortiGatePublicSecGrp": {
 			"Type": "AWS::EC2::SecurityGroup",
 			"Properties": {
 				"VpcId": {
 					"Ref": "VPCID"
 				},
-				"GroupDescription": "FortigateSecGrp",
+				"GroupDescription": "FortiGatePublicSecGrp",
 				"SecurityGroupIngress": [
 					{
-						"Description": "Allow remote access to FGT",
+						"Description": "Allow remote access to FGT for the public subnet",
 						"IpProtocol": "-1",
 						"FromPort": "0",
 						"ToPort": "65535",
 						"CidrIp": {
 							"Ref": "CIDRForInstanceAccess"
 						}
-					},
+					}
+				],
+				"Tags": [
 					{
-						"Description": "Allow local VPC access to FGT",
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-public"
+						}
+					}
+				]
+			}
+		},
+		"FortiGatePrivateSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortiGatePrivateSecGrp",
+				"SecurityGroupIngress": [
+					{
+						"Description": "Allow local VPC access to FGT for the private subnet",
 						"IpProtocol": "-1",
 						"FromPort": "0",
 						"ToPort": "65535",
@@ -402,22 +426,75 @@
 							"Ref": "VPCCIDR"
 						}
 					}
+				],
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-private"
+						}
+					}
 				]
 			}
 		},
-		"FortiGateSecGrpHArule": {
-			"DependsOn": "FortiGateSecGrp",
+		"FortiGateHAMgmtSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortiGateHAMgmtSecGrp",
+				"SecurityGroupIngress": [
+					{
+						"Description": "Allow remote access to FGT for the HA management subnet",
+						"IpProtocol": "-1",
+						"FromPort": "0",
+						"ToPort": "65535",
+						"CidrIp": {
+							"Ref": "CIDRForInstanceAccess"
+						}
+					}
+				],
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-hamgmt"
+						}
+					}
+				]
+			}
+		},
+		"FortiGateHASyncSecGrp": {
+			"Type": "AWS::EC2::SecurityGroup",
+			"Properties": {
+				"VpcId": {
+					"Ref": "VPCID"
+				},
+				"GroupDescription": "FortigateHASyncSecGrp",
+				"Tags": [
+					{
+						"Key": "Name",
+						"Value": {
+							"Fn::Sub": "${AWS::StackName}-hasync"
+						}
+					}
+				]
+			}
+		},
+		"FortiGateHASyncSecGrpRule": {
+			"DependsOn": "FortiGateHASyncSecGrp",
 			"Type": "AWS::EC2::SecurityGroupIngress",
 			"Properties": {
 				"GroupId": {
-					"Ref": "FortiGateSecGrp"
+					"Ref": "FortiGateHASyncSecGrp"
 				},
-				"Description": "Allow FGTs to access each other",
+				"Description": "Allow FGTs to access each other via HA Sync subnet",
 				"IpProtocol": "-1",
 				"FromPort": "0",
 				"ToPort": "65535",
 				"SourceSecurityGroupId": {
-					"Ref": "FortiGateSecGrp"
+					"Ref": "FortiGateHASyncSecGrp"
 				}
 			}
 		},
@@ -618,7 +695,7 @@
 				"Description": "port1",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePublicSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -687,7 +764,7 @@
 				"Description": "port1",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePublicSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -789,7 +866,7 @@
 				"Description": "port2",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePrivateSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -854,7 +931,7 @@
 				"Description": "port2",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGatePrivateSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -898,7 +975,7 @@
 				"Description": "port3",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHASyncSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -942,7 +1019,7 @@
 				"Description": "port4",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHAMgmtSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -986,7 +1063,7 @@
 				"Description": "port3",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHASyncSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -1030,7 +1107,7 @@
 				"Description": "port4",
 				"GroupSet": [
 					{
-						"Ref": "FortiGateSecGrp"
+						"Ref": "FortiGateHAMgmtSecGrp"
 					}
 				],
 				"SourceDestCheck": "false",
@@ -1548,6 +1625,18 @@
 							"}"
 						]
 					]
+				}
+			}
+		},
+		"PrivateRoute1": {
+			"Type": "AWS::EC2::Route",
+			"Properties": {
+				"RouteTableId": {
+					"Ref": "PrivateSubnetRouteTableID"
+				},
+				"DestinationCidrBlock": "0.0.0.0/0",
+				"NetworkInterfaceId": {
+					"Ref": "fgt1eni1"
 				}
 			}
 		}


### PR DESCRIPTION
This PR more accurately reflects how Fortigates are typically used in production environments.

Instead of one big security group for all the interfaces, create a separate security group for each of the following:

- Public
- Private
- HASync
- HAMgmt

This allows for more granular security controls on each of the interfaces. For example, one can now allow management stations ONLY to the HAMgmt interfaces, while still allowing 0.0.0.0/0 to the Public interface (for example, SSLVPN termination).

It also secures the HASync interface to only allow communication between Fortigates, as well as only allowing internal traffic on the Private interfaces.

In addition, an entry into the base VPC for the private route to the FGT eni is also created, which previously needed to be manually created after deployment.

This configuration has been running in a production environment for over two weeks with no issues.