### PR TITLE
Update FGCP_DualAZ_ExistingVPC.template.json

### DIFF
--- a/FGCP/6.4/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/6.4/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -394,17 +394,24 @@
 						"CidrIp": {
 							"Ref": "CIDRForInstanceAccess"
 						}
-					},
-					{
-						"Description": "Allow local VPC access to FGT",
-						"IpProtocol": "-1",
-						"FromPort": "0",
-						"ToPort": "65535",
-						"CidrIp": {
-							"Ref": "VPCCIDR"
-						}
 					}
 				]
+			}
+		},
+		"InstanceIngress": {
+ 			"DependsOn": "FortiGateSecGrp",
+			"Type": "AWS::EC2::SecurityGroupIngress",
+			"Properties": {
+				"GroupId": {
+					"Ref": "FortiGateSecGrp"
+				},
+				"Description": "Allow FGTs to talk amongst themselves",
+			"IpProtocol": "-1",
+			"FromPort": "0",
+			"ToPort": "65535",
+			"CidrIp": {
+				"Ref": "VPCCIDR"
+				}
 			}
 		},
 		"FortiGateSecGrpHArule": {


### PR DESCRIPTION
When using non-default VPC, and accessing instances from outside the VPC, Cloudformation objects to creating two rules from different networks during creation of a SG. 

Error "You have specified two resources that belong to different networks."

Changed the SG resource to create with a single rule, then add VPC access as a seperate resource.