### PR TITLE
Adjusted LambdaRole Permission

### DIFF
--- a/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -1264,6 +1264,7 @@
 				]
 			}
 		},
+		{
 		"ImageFunction": {
 			"Type": "AWS::Lambda::Function",
 			"Properties": {

--- a/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -408,7 +408,6 @@
 			}
 		},
 		"FortiGateSecGrpHArule": {
-			"DependsOn": "FortiGateSecGrp",
 			"Type": "AWS::EC2::SecurityGroupIngress",
 			"Properties": {
 				"GroupId": {
@@ -811,8 +810,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "ClusterEIP"
+			}
 		},
 		"fgt1eni1": {
 			"Type": "AWS::EC2::NetworkInterface",
@@ -1103,8 +1101,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "Fgt1EIP"
+			}
 		},
 		"Fgt2EIPASSOCIATION": {
 			"Type": "AWS::EC2::EIPAssociation",
@@ -1131,8 +1128,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "Fgt2EIP"
+			}
 		},
 		"LambdaRole": {
 			"Type": "AWS::IAM::Role",
@@ -1156,23 +1152,110 @@
 				"Path": "/",
 				"Policies": [
 					{
-						"PolicyName": "S3AccessRole",
+						"PolicyName": "ConfigBuilder",
 						"PolicyDocument": {
 							"Version": "2012-10-17",
 							"Statement": [
 								{
+									"Sid": "CreateLogGroups",
 									"Effect": "Allow",
-									"Action": [
-										"s3:PutObject",
-										"ec2:DescribeImages"
-									],
-									"Resource": "*"
+									"Action": "logs:CreateLogGroup",
+									"Resource": {
+										"Fn::Join": [
+											":",
+											[
+												"arn",
+												{
+													"Ref": "AWS::Partition"
+												},
+												"logs",
+												{
+													"Ref": "AWS::Region"
+												},
+												{
+													"Ref": "AWS::AccountId"
+												},
+												"*"
+											]
+										]
+									}
 								},
 								{
+									"Sid": "WriteLogs",
 									"Effect": "Allow",
 									"Action": [
-										"logs:*"
+										"logs:CreateLogStream",
+										"logs:PutLogEvents"
 									],
+									"Resource": {
+										"Fn::Join": [
+											":",
+											[
+												"arn",
+												{
+													"Ref": "AWS::Partition"
+												},
+												"logs",
+												{
+													"Ref": "AWS::Region"
+												},
+												{
+													"Ref": "AWS::AccountId"
+												},
+												"log-group:/aws/lambda/*"
+											]
+										]
+									}
+								},
+								{
+									"Sid": "WriteConfigs",
+									"Effect": "Allow",
+									"Action": "s3:putObject",
+									"Resource": [
+										{
+											"Fn::Join": [
+												":",
+												[
+													"arn",
+													{
+														"Ref": "AWS::Partition"
+													},
+													"s3::",
+													{
+														"Ref": "InitS3Bucket"
+													}
+												]
+											]
+										},
+										{
+											"Fn::Join": [
+												":",
+												[
+													"arn",
+													{
+														"Ref": "AWS::Partition"
+													},
+													"s3::",
+													{
+														"Fn::Join": [
+															"",
+															[
+																{
+																"Ref": "InitS3Bucket"
+																},
+																"/*"
+															]
+														]
+													}
+												]
+											]
+										}
+									]
+								},
+								{
+									"Sid": "LookupAMIs",
+									"Effect": "Allow",
+									"Action": "ec2:DescribeImages",
 									"Resource": "*"
 								}
 							]

--- a/FGCP/7.0/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
@@ -393,7 +393,6 @@
 			}
 		},
 		"FortiGateSecGrpHArule": {
-			"DependsOn": "FortiGateSecGrp",
 			"Type": "AWS::EC2::SecurityGroupIngress",
 			"Properties": {
 				"GroupId": {
@@ -812,8 +811,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "ClusterEIP"
+			}
 		},
 		"fgt1eni1": {
 			"Type": "AWS::EC2::NetworkInterface",
@@ -1125,8 +1123,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "Fgt1EIP"
+			}
 		},
 		"Fgt2EIPASSOCIATION": {
 			"Type": "AWS::EC2::EIPAssociation",
@@ -1153,8 +1150,7 @@
 						}
 					]
 				}
-			},
-			"DependsOn": "Fgt2EIP"
+			}
 		},
 		"LambdaRole": {
 			"Type": "AWS::IAM::Role",
@@ -1178,106 +1174,114 @@
 				"Path": "/",
 				"Policies": [
 					{
-						"Sid": "CreateLogGroups",
-						"Effect": "Allow",
-						"Action": "logs:CreateLogGroup",
-						"Resource": {
-							"Fn::Join": [
-								":",
-								[
-									"arn",
-									{
-										"Ref": "AWS::Partition"
-									},
-									"logs",
-									{
-										"Ref": "AWS::Region"
-									},
-									{
-										"Ref": "AWS::AccountId"
-									},
-									"*"
-								]
-							]
-						}
-					},
-					{
-						"Sid": "WriteLogs",
-						"Effect": "Allow",
-						"Action": [
-							"logs:CreateLogStream",
-							"logs:PutLogEvents"
-						],
-						"Resource": {
-							"Fn::Join": [
-								":",
-								[
-									"arn",
-									{
-										"Ref": "AWS::Partition"
-									},
-									"logs",
-									{
-										"Ref": "AWS::Region"
-									},
-									{
-										"Ref": "AWS::AccountId"
-									},
-									"log-group:/aws/lambda/*"
-								]
-							]
-						}
-					},
-					{
-						"Sid": "WriteConfigs",
-						"Effect": "Allow",
-						"Action": "s3:putObject",
-						"Resource": [
-							{
-								"Fn::Join": [
-									":",
-									[
-										"arn",
-										{
-											"Ref": "AWS::Partition"
-										},
-										"s3::",
-										{
-											"Ref": "InitS3Bucket"
-										}
-									]
-								]
-							},
-							{
-								"Fn::Join": [
-									":",
-									[
-										"arn",
-										{
-											"Ref": "AWS::Partition"
-										},
-										"s3::",
+						"PolicyName": "ConfigBuilder",
+						"PolicyDocument": {
+							"Version": "2012-10-17",
+							"Statement": [
+								{
+									"Sid": "CreateLogGroups",
+									"Effect": "Allow",
+									"Action": "logs:CreateLogGroup",
+									"Resource": {
+										"Fn::Join": [
+											":",
+											[
+												"arn",
+												{
+													"Ref": "AWS::Partition"
+												},
+												"logs",
+												{
+													"Ref": "AWS::Region"
+												},
+												{
+													"Ref": "AWS::AccountId"
+												},
+												"*"
+											]
+										]
+									}
+								},
+								{
+									"Sid": "WriteLogs",
+									"Effect": "Allow",
+									"Action": [
+										"logs:CreateLogStream",
+										"logs:PutLogEvents"
+									],
+									"Resource": {
+										"Fn::Join": [
+											":",
+											[
+												"arn",
+												{
+													"Ref": "AWS::Partition"
+												},
+												"logs",
+												{
+													"Ref": "AWS::Region"
+												},
+												{
+													"Ref": "AWS::AccountId"
+												},
+												"log-group:/aws/lambda/*"
+											]
+										]
+									}
+								},
+								{
+									"Sid": "WriteConfigs",
+									"Effect": "Allow",
+									"Action": "s3:putObject",
+									"Resource": [
 										{
 											"Fn::Join": [
-												"",
+												":",
 												[
+													"arn",
 													{
-													"Ref": "InitS3Bucket"
+														"Ref": "AWS::Partition"
 													},
-													"/*"
+													"s3::",
+													{
+														"Ref": "InitS3Bucket"
+													}
+												]
+											]
+										},
+										{
+											"Fn::Join": [
+												":",
+												[
+													"arn",
+													{
+														"Ref": "AWS::Partition"
+													},
+													"s3::",
+													{
+														"Fn::Join": [
+															"",
+															[
+																{
+																"Ref": "InitS3Bucket"
+																},
+																"/*"
+															]
+														]
+													}
 												]
 											]
 										}
 									]
-								]
-							}
-						]
-					},
-					{
-						"Sid": "LookupAMIs",
-						"Effect": "Allow",
-						"Action": "ec2:DescribeImages",
-						"Resource": "*"
+								},
+								{
+									"Sid": "LookupAMIs",
+									"Effect": "Allow",
+									"Action": "ec2:DescribeImages",
+									"Resource": "*"
+								}
+							]
+						}
 					}
 				]
 			}

--- a/FGCP/7.0/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/SingleAZ/FGCP_SingleAZ_ExistingVPC.template.json
@@ -1178,27 +1178,106 @@
 				"Path": "/",
 				"Policies": [
 					{
-						"PolicyName": "S3AccessRole",
-						"PolicyDocument": {
-							"Version": "2012-10-17",
-							"Statement": [
-								{
-									"Effect": "Allow",
-									"Action": [
-										"s3:PutObject",
-										"ec2:DescribeImages"
-									],
-									"Resource": "*"
-								},
-								{
-									"Effect": "Allow",
-									"Action": [
-										"logs:*"
-									],
-									"Resource": "*"
-								}
+						"Sid": "CreateLogGroups",
+						"Effect": "Allow",
+						"Action": "logs:CreateLogGroup",
+						"Resource": {
+							"Fn::Join": [
+								":",
+								[
+									"arn",
+									{
+										"Ref": "AWS::Partition"
+									},
+									"logs",
+									{
+										"Ref": "AWS::Region"
+									},
+									{
+										"Ref": "AWS::AccountId"
+									},
+									"*"
+								]
 							]
 						}
+					},
+					{
+						"Sid": "WriteLogs",
+						"Effect": "Allow",
+						"Action": [
+							"logs:CreateLogStream",
+							"logs:PutLogEvents"
+						],
+						"Resource": {
+							"Fn::Join": [
+								":",
+								[
+									"arn",
+									{
+										"Ref": "AWS::Partition"
+									},
+									"logs",
+									{
+										"Ref": "AWS::Region"
+									},
+									{
+										"Ref": "AWS::AccountId"
+									},
+									"log-group:/aws/lambda/*"
+								]
+							]
+						}
+					},
+					{
+						"Sid": "WriteConfigs",
+						"Effect": "Allow",
+						"Action": "s3:putObject",
+						"Resource": [
+							{
+								"Fn::Join": [
+									":",
+									[
+										"arn",
+										{
+											"Ref": "AWS::Partition"
+										},
+										"s3::",
+										{
+											"Ref": "InitS3Bucket"
+										}
+									]
+								]
+							},
+							{
+								"Fn::Join": [
+									":",
+									[
+										"arn",
+										{
+											"Ref": "AWS::Partition"
+										},
+										"s3::",
+										{
+											"Fn::Join": [
+												"",
+												[
+													{
+													"Ref": "InitS3Bucket"
+													},
+													"/*"
+												]
+											]
+										}
+									]
+								]
+							}
+						]
+					},
+					{
+						"Sid": "LookupAMIs",
+						"Effect": "Allow",
+						"Action": "ec2:DescribeImages",
+						"Resource": "*"
 					}
 				]
 			}


### PR DESCRIPTION
Hi,
I built some finer tuned permissions around the Lambda Role, which limits the role to only accessing the s3 bucket defined in the template, as well as the logstream scope reduced from logs*.

Applied these to the 7.0 FGCP templates, both single/dual AZ. Also removed old dependson req's which are no longer needed.