### PR TITLE
corrected json on DualAZ template

### DIFF
--- a/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -1263,6 +1263,7 @@
 					}
 				]
 			}
+		},
 		"ImageFunction": {
 			"Type": "AWS::Lambda::Function",
 			"Properties": {


### PR DESCRIPTION
line 1266 is missing '},' added and corrected. Validated template runs via CFT