### PR TITLE
Fix error of AMI not found when deploy  FG version 7.0 in AWS UAE region

### DIFF
--- a/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -1291,7 +1291,7 @@
 								"    try:",
 								"        resp = client.describe_images(",
 								"            Filters=[{'Name': 'name', 'Values': [event['ResourceProperties']['LicenseType']]}],",
-								"            Owners=['279184472064', '679593333241', '464423754048', '211372476111', '345084742485', '874634375141', '939706979954', '786482375130']",
+								"            Owners=['679593333241', '464423754048', '211372476111', '345084742485', '874634375141', '939706979954', '786482375130']",
 								"        )",
 								"    except Exception as error:",
 								"        logger.error('<--!! Exception: {}'.format(error))",

--- a/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
+++ b/FGCP/7.0/DualAZ/FGCP_DualAZ_ExistingVPC.template.json
@@ -1291,7 +1291,7 @@
 								"    try:",
 								"        resp = client.describe_images(",
 								"            Filters=[{'Name': 'name', 'Values': [event['ResourceProperties']['LicenseType']]}],",
-								"            Owners=['679593333241', '464423754048', '211372476111', '345084742485', '874634375141', '939706979954', '786482375130']",
+								"            Owners=['279184472064', '679593333241', '464423754048', '211372476111', '345084742485', '874634375141', '939706979954', '786482375130']",
 								"        )",
 								"    except Exception as error:",
 								"        logger.error('<--!! Exception: {}'.format(error))",


### PR DESCRIPTION
Update FGCP_DualAZ_ExistingVPC.template.json.

By adding the owner account id of UAE FortiGate AMI (279184472064) to the filter of ImageFunction Lambda, the UAE AMI will be returned at the response and the deployment will work as expected
